### PR TITLE
Change client to accept json data directly

### DIFF
--- a/pyopnsense/client.py
+++ b/pyopnsense/client.py
@@ -60,11 +60,11 @@ class OPNClient(object):
         )
         return self._process_response(response, raw)
 
-    def _post(self, endpoint, body, raw=False):
+    def _post(self, endpoint, data, raw=False):
         req_url = "{}/{}".format(self.base_url, endpoint)
         response = requests.post(
             req_url,
-            data=body,
+            json=data,
             verify=self.verify_cert,
             auth=(self.api_key, self.api_secret),
             timeout=self.timeout,


### PR DESCRIPTION
since requests can handle json input directly I suggest to change the _post behaviour to accept python dictionaries directly and hand it over to requests to convert it to json automatically